### PR TITLE
parsing flags lead to weird errors, so avoid that

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ Configuration options:
 Running locally on currently selected kubernetes cluster with go ~> 1.12.9:
 ```bash
 unset GOPATH
+go mod vendor # install into local directory instead of global path
 go build -o .build/remediator cmd/remediator/app.go
-.build/remediator -kubeconfig ~/.kube/config
 
-# test remediators
+.build/remediator # run on cluster from $KUBECONFIG (defaults to ~/.kube/config) 
+
+# test remediator by seeing if this pod is rescheduled when it crashloops after it's restarted failureThreshold times
 kubectl apply -f kubernetes/crashloop_pod.yml
 ```

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"flag"
 	"go.uber.org/zap"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,11 +34,11 @@ func newClientSet() (*kubernetes.Clientset, error) {
 	var err error
 	var config *restclient.Config
 	if os.Getenv("KUBERNETES_SERVICE_HOST") == "" {
-		// Read kubeconfig flag from command line
-		kubeconfig := flag.String("kubeconfig", filepath.Join(os.Getenv("HOME"), ".kube", "config"), "")
-		flag.Parse()
-		config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
-
+		kubeconfig := os.Getenv("KUBECONFIG")
+		if kubeconfig == "" {
+			kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+		}
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 	} else {
 		// Reads config when in cluster
 		config, err = rest.InClusterConfig()


### PR DESCRIPTION
```
.build/remediator
{"level":"info","caller":"remediator/crashloopbackoff_rescheduler.go:123","message":"Reading config","file":"config/crash_loop_back_off_rescheduler.json"}
{"level":"info","caller":"remediator/crashloopbackoff_rescheduler.go:134","message":"Config map[annotation:kube-remediator/CrashLoopBackOffRemediator failurethreshold:5 namespace:]"}
.build/remediator flag redefined: kubeconfig
panic: .build/remediator flag redefined: kubeconfig
```

```
.build/remediator -kubeconfig ~/.kube/config
{"level":"info","caller":"remediator/crashloopbackoff_rescheduler.go:123","message":"Reading config","file":"config/crash_loop_back_off_rescheduler.json"}
{"level":"info","caller":"remediator/crashloopbackoff_rescheduler.go:134","message":"Config map[annotation:kube-remediator/CrashLoopBackOffRemediator failurethreshold:5 namespace:]"}
.build/remediator flag redefined: kubeconfig
panic: .build/remediator flag redefined: kubeconfig
```

@aksgithub 