### PR TITLE
Fix tests

### DIFF
--- a/pkg/metrics/crashloopbackoff_metrics.go
+++ b/pkg/metrics/crashloopbackoff_metrics.go
@@ -15,7 +15,7 @@ func NewCrashLoopBackOffMetrics(logger *zap.Logger) *CrashLoopBackOff_Metrics {
 
 }
 
-func (c *CrashLoopBackOff_Metrics) RegisterMetrics() {
+func (c *CrashLoopBackOff_Metrics) Register() {
 	c.pods_count = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "crashloopbackoff_pods_rescheduled",
@@ -24,6 +24,10 @@ func (c *CrashLoopBackOff_Metrics) RegisterMetrics() {
 		[]string{"action"},
 	)
 	prometheus.MustRegister(c.pods_count)
+}
+
+func (c *CrashLoopBackOff_Metrics) UnRegister() {
+	prometheus.Unregister(c.pods_count)
 }
 
 func (c *CrashLoopBackOff_Metrics) UpdateRescheduledCount() {

--- a/pkg/remediator/crashloopbackoff_rescheduler.go
+++ b/pkg/remediator/crashloopbackoff_rescheduler.go
@@ -50,6 +50,7 @@ func (p *CrashLoopBackOffRescheduler) Run(ctx context.Context, wg *sync.WaitGrou
 	informer.Run(ctx.Done())
 
 	<-ctx.Done()
+	p.metrics.UnRegister()
 	p.logger.Info("Stopping", zap.String("reason", "Signal"))
 }
 
@@ -139,7 +140,7 @@ func NewCrashLoopBackOffRescheduler(logger *zap.Logger,
 	}
 
 	metrics := metrics.NewCrashLoopBackOffMetrics(logger)
-	metrics.RegisterMetrics()
+	metrics.Register()
 
 	informerFactory, err := k8s.NewSharedInformerFactory(logger, filter.namespace)
 	if err != nil {


### PR DESCRIPTION
Issues with tests:
1. panic on closing and already closed channel in shared informer
 - Since, crashloop remediator was initialized at suite level and reused from one test to other, shared informer panic'ed on closing already closed channel
2. test compilation 
- metrics for crashloop remediator is concealed and so no need to initialize and pass from test code
3. with #1 is fixed, prometheus complained about duplicate registration of metrics
- unregister prometheus metrics on exit from crashloop remediator.
4. unrelated issue -> cancel() is called from main and signalHandler routine. 
- Just call cancel from signalHandler. Fixes: ```{"level":"error","caller":"http/http.go:37","message":"Error listening","error":"http: Server closed","stacktrace":"github.com/aksgithub/kube_remediator/pkg/http.(*Server).Serve.func1\n\t/Users/ashah/Code/zendesk/kube_remediator/pkg/http/http.go:37"}``` on exit.